### PR TITLE
Add configMaps support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-.idea/
 target/
-.bloop/
-.metals/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 target/
+.bloop/
+.metals/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,4 @@
-version = 2.0.0-RC4
-
+version = "2.0.0"
 style = default
 maxColumn = 100
 project.git = true

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,5 @@
+version = 2.0.0-RC4
+
 style = default
 maxColumn = 100
 project.git = true

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,9 @@
 ## Ciris Kubernetes
-Kubernetes secrets support for [Ciris][ciris] using the official [Kubernetes Java client][kubernetes-java-client].
+
+Kubernetes support for [Ciris][ciris] using the official [Kubernetes Java client][kubernetes-java-client].
 
 ### Getting Started
+
 To get started with [sbt][sbt], simply add the following lines to your `build.sbt` file.
 
 ```scala
@@ -13,6 +15,11 @@ libraryDependencies += "com.ovoenergy" %% "ciris-kubernetes" % "0.10"
 The library is published for Scala 2.11 and 2.12.
 
 ### Usage
+
+The library supports Kubernetes secrets and config maps.
+
+#### Secrets
+
 Start with `import ciris.kubernetes._`, create an `ApiClient`, and register any authenticators. You can then set the namespace for your secrets with `secretInNamespace`, like in the following example. You can then load secrets by specifying the secret name. If there is more than one entry for the secret, you can also specify the key to retrieve.
 
 ```scala
@@ -71,10 +78,9 @@ config.unsafeRunSync()
 //   ... 36 elided
 ```
 
-#### ConfigMaps
+#### Config Maps
 
-ConfigMaps are supported and these work in much the same way as secrets.
-The following example demonstrates using configMaps for a Pizza delivery API.
+Config maps are supported in a similar fashion to how secrets are supported.
 
 ```scala
 import cats.effect.IO
@@ -87,7 +93,7 @@ final case class Config(
   appName: String,
   pizzaBrand: String,
   deliveryRadius: Int,
-  isDeliveryCharge: Boolean 
+  isDeliveryCharge: Boolean
 )
 
 val config: IO[Config] =
@@ -96,15 +102,15 @@ val config: IO[Config] =
     apiClient <- defaultApiClient[IO]
     configMap = configMapInNamespace("pizza", apiClient)
     config <- loadConfig(
-      configMap[String]("pizzaBrand"), // Key can be omitted if configMap has only one entry
-      configMap[Int]("delivery", "radius"), // Key is necessary if configMap has multiple entries
+      configMap[String]("pizzaBrand"), // Key can be omitted if config map has only one entry
+      configMap[Int]("delivery", "radius"), // Key is necessary if config map has multiple entries
       configMap[Boolean]("delivery", "charge")
     ) { (pizzaBrand, deliveryRadius, isDeliveryCharge) =>
       Config(
         appName = "my-pizza-api",
         pizzaBrand = pizzaBrand,
         deliveryRadius = deliveryRadius,
-        isDeliveryCharge = isDeliveryCharge 
+        isDeliveryCharge = isDeliveryCharge
       )
     }.orRaiseThrowable
   } yield config

--- a/src/main/scala/ciris/kubernetes.scala
+++ b/src/main/scala/ciris/kubernetes.scala
@@ -11,19 +11,39 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 object kubernetes {
-  final case class SecretKey(
-    namespace: String,
-    name: String,
-    key: Option[String]
-  ) {
-    override def toString: String = key match {
+
+  sealed trait ConfigEntryKey {
+    def namespace: String
+    def name: String
+    def key: Option[String]
+
+    def show: String = key match {
       case Some(key) => s"namespace = $namespace, name = $name, key = $key"
       case None      => s"namespace = $namespace, name = $name"
     }
   }
 
+  final case class SecretKey(
+    namespace: String,
+    name: String,
+    key: Option[String]
+  ) extends ConfigEntryKey {
+    override def toString: String = show
+  }
+
+  final case class ConfigMapKey(
+    namespace: String,
+    name: String,
+    key: Option[String]
+  ) extends ConfigEntryKey {
+    override def toString: String = show
+  }
+
   val SecretKeyType: ConfigKeyType[SecretKey] =
     ConfigKeyType("kubernetes secret")
+
+  val ConfigMapKeyType: ConfigKeyType[ConfigMapKey] =
+    ConfigKeyType("kubernetes configMap")
 
   private def fetchSecretEntries(
     client: ApiClient,
@@ -34,42 +54,77 @@ object kubernetes {
     api.readNamespacedSecret(name, namespace, null, null, null).getData.asScala.toMap
   }
 
+  private def fetchConfigMapEntries(
+    client: ApiClient,
+    name: String,
+    namespace: String
+  ): Try[Map[String, String]] = Try {
+    val api = new CoreV1Api(client)
+    api.readNamespacedConfigMap(name, namespace, null, null, null).getData().asScala.toMap
+  }
+
+  private def parseFetchResult[K, T](
+    fetchResult: Try[T],
+    ConfigType: ConfigKeyType[K],
+    config: K
+  ): Either[ConfigError, T] =
+    fetchResult match {
+      case Success(entries) => Right(entries)
+      case Failure(cause: ApiException) if cause.getMessage == "Not Found" =>
+        Left(ConfigError.missingKey(config, ConfigType))
+      case Failure(cause) =>
+        Left(ConfigError.readException(config, ConfigType, cause))
+    }
+
+  private def pickEntry[V, T <: ConfigEntryKey](
+    entries: Map[String, V],
+    configEntry: T,
+    ConfigType: ConfigKeyType[T]
+  ) = {
+    def availableKeys = s"available keys are: ${entries.keys.toList.sorted.mkString(", ")}"
+
+    configEntry.key match {
+      case Some(key) =>
+        entries
+          .get(key)
+          .toRight(ConfigError {
+            s"${ConfigType.name.capitalize} [$configEntry] exists but there is no entry with key [$key]; $availableKeys"
+          })
+      case None if entries.size == 1 =>
+        Right(entries.values.head)
+      case _ =>
+        Left(ConfigError {
+          s"There is more than one entry available for ${ConfigType.name} [$configEntry], please specify which key to use; $availableKeys"
+        })
+    }
+  }
+
   private def secretSource(client: ApiClient): ConfigSource[Id, SecretKey, String] =
     ConfigSource(SecretKeyType) { secret =>
       val secretEntries =
         fetchSecretEntries(client, secret.name, secret.namespace) match {
-          case Success(entries) => Right(entries)
-          case Failure(cause: ApiException) if cause.getMessage == "Not Found" =>
-            Left(ConfigError.missingKey(secret, SecretKeyType))
-          case Failure(cause) =>
-            Left(ConfigError.readException(secret, SecretKeyType, cause))
+          case fetchResult => parseFetchResult(fetchResult, SecretKeyType, secret)
         }
 
-      val secretValueBytes =
-        secretEntries.right.flatMap { entries =>
-          def availableKeys = s"available keys are: ${entries.keys.toList.sorted.mkString(", ")}"
-
-          secret.key match {
-            case Some(key) =>
-              entries
-                .get(key)
-                .toRight(ConfigError {
-                  s"${SecretKeyType.name.capitalize} [$secret] exists but there is no entry with key [$key]; $availableKeys"
-                })
-            case None if entries.size == 1 =>
-              Right(entries.values.head)
-            case _ =>
-              Left(ConfigError {
-                s"There is more than one entry available for ${SecretKeyType.name} [$secret], please specify which key to use; $availableKeys"
-              })
-          }
-        }
+      val secretValueBytes = secretEntries.right
+        .flatMap(pickEntry(_, secret, SecretKeyType))
 
       val secretValue =
         secretValueBytes.right
           .map(bytes => ByteString.of(bytes, 0, bytes.length).utf8)
 
       secretValue
+    }
+
+  private def configMapSource(client: ApiClient): ConfigSource[Id, ConfigMapKey, String] =
+    ConfigSource(ConfigMapKeyType) { configMap =>
+      val entries =
+        fetchConfigMapEntries(client, configMap.name, configMap.namespace) match {
+          case fetchResult => parseFetchResult(fetchResult, ConfigMapKeyType, configMap)
+        }
+
+      entries.right
+        .flatMap(pickEntry(_, configMap, ConfigMapKeyType))
     }
 
   def defaultApiClient[F[_]](implicit F: Sync[F]): F[ApiClient] =
@@ -128,4 +183,56 @@ object kubernetes {
     override def toString: String =
       s"SecretInNamespace($namespace)"
   }
+
+  def configMapInNamespace[F[_]](
+    namespace: String,
+    apiClient: ApiClient
+  )(implicit F: Sync[F]): ConfigMapInNamespace[F] =
+    new ConfigMapInNamespace[F](
+      namespace = namespace,
+      apiClient = apiClient
+    )
+
+  final class ConfigMapInNamespace[F[_]] private[kubernetes] (
+    namespace: String,
+    apiClient: ApiClient
+  )(implicit F: Sync[F]) {
+    private val source: ConfigSource[F, ConfigMapKey, String] =
+      ConfigSource.applyF(ConfigMapKeyType) { key =>
+        configMapSource(apiClient)
+          .suspendF[F]
+          .read(key)
+          .value
+      }
+
+    def apply[Value](name: String)(
+      implicit decoder: ConfigDecoder[String, Value]
+    ): ConfigEntry[F, ConfigMapKey, String, Value] = {
+      val configMapKey =
+        ConfigMapKey(
+          namespace = namespace,
+          name = name,
+          key = None
+        )
+
+      source.read(configMapKey).decodeValue[Value]
+    }
+
+    def apply[Value](name: String, key: String)(
+      implicit decoder: ConfigDecoder[String, Value]
+    ): ConfigEntry[F, ConfigMapKey, String, Value] = {
+      val configMapKey =
+        ConfigMapKey(
+          namespace = namespace,
+          name = name,
+          key = Some(key)
+        )
+
+      source.read(configMapKey).decodeValue[Value]
+    }
+
+    override def toString: String =
+      s"ConfigMapInNamespace($namespace)"
+  }
+
 }


### PR DESCRIPTION
This adds support to use kubernetes configMaps in the same way as is done for secrets.

I have tried to refactor to reduce unnecessary duplication. I feel this could be separated into 2 files for secrets/configmaps.