### PR TITLE
Update to Ciris 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,11 @@ lazy val scalaSettings = Seq(
 )
 
 libraryDependencies ++= Seq(
+  "io.kubernetes" % "client-java" % "12.0.0",
+  "io.kubernetes" % "client-java-api" % "12.0.0",
   "is.cir" %% "ciris" % "1.2.1",
-  "io.kubernetes" % "client-java" % "12.0.0"
+  "org.typelevel" %% "cats-core" % "2.1.1",
+  "org.typelevel" %% "cats-effect" % "2.1.4"
 )
 
 licenses += ("MIT", url("https://opensource.org/licenses/MIT"))

--- a/build.sbt
+++ b/build.sbt
@@ -15,15 +15,41 @@ lazy val metadataSettings = Seq(
 
 lazy val scalaSettings = Seq(
   scalaVersion := "2.13.5",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.13")
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.13"),
+  scalacOptions ++= {
+    val commonScalacOptions =
+      Seq(
+        "-deprecation",
+        "-encoding",
+        "UTF-8",
+        "-feature",
+        "-unchecked",
+        // "-Xfatal-warnings",
+        "-language:higherKinds",
+        "-Xlint",
+        "-Ywarn-dead-code",
+        "-Ywarn-numeric-widen",
+        "-Ywarn-value-discard",
+        "-Ywarn-unused",
+        "Wunused:nowarn",
+        "-Xlint:unused"
+      )
+
+    val scala212ScalacOptions =
+      if (scalaVersion.value.startsWith("2.12")) {
+        Seq("-Yno-adapted-args", "-Ypartial-unification")
+      } else Seq()
+
+    commonScalacOptions ++
+      scala212ScalacOptions
+  },
+  Compile / console / scalacOptions --= Seq("-Xlint", "-Ywarn-unused")
 )
 
 libraryDependencies ++= Seq(
   "io.kubernetes" % "client-java" % "12.0.0",
   "io.kubernetes" % "client-java-api" % "12.0.0",
-  "is.cir" %% "ciris" % "1.2.1",
-  "org.typelevel" %% "cats-core" % "2.1.1",
-  "org.typelevel" %% "cats-effect" % "2.1.4"
+  "is.cir" %% "ciris" % "2.0.0-RC3"
 )
 
 licenses += ("MIT", url("https://opensource.org/licenses/MIT"))

--- a/src/main/scala/ciris/ConfigMapInNamespace.scala
+++ b/src/main/scala/ciris/ConfigMapInNamespace.scala
@@ -1,23 +1,22 @@
 package ciris.kubernetes
 
-import cats.effect.Blocker
 import ciris.ConfigValue
 import io.kubernetes.client.openapi.ApiClient
 
-sealed abstract class ConfigMapInNamespace {
-  def apply(name: String): ConfigValue[String]
+sealed abstract class ConfigMapInNamespace[F[_]] {
+  def apply(name: String): ConfigValue[F, String]
 
-  def apply(name: String, key: String): ConfigValue[String]
+  def apply(name: String, key: String): ConfigValue[F, String]
 }
 
 private[kubernetes] final object ConfigMapInNamespace {
-  final def apply(namespace: String, client: ApiClient, blocker: Blocker): ConfigMapInNamespace =
-    new ConfigMapInNamespace {
-      override final def apply(name: String): ConfigValue[String] =
-        configMap(client, name, namespace, None, blocker)
+  final def apply[F[_]](namespace: String, client: ApiClient): ConfigMapInNamespace[F] =
+    new ConfigMapInNamespace[F] {
+      override final def apply(name: String): ConfigValue[F, String] =
+        configMap(client, name, namespace, None)
 
-      override final def apply(name: String, key: String): ConfigValue[String] =
-        configMap(client, name, namespace, Some(key), blocker)
+      override final def apply(name: String, key: String): ConfigValue[F, String] =
+        configMap(client, name, namespace, Some(key))
 
       override final def toString: String =
         s"ConfigMapInNamespace($namespace)"

--- a/src/main/scala/ciris/SecretInNamespace.scala
+++ b/src/main/scala/ciris/SecretInNamespace.scala
@@ -1,23 +1,22 @@
 package ciris.kubernetes
 
-import cats.effect.Blocker
 import ciris.ConfigValue
 import io.kubernetes.client.openapi.ApiClient
 
-sealed abstract class SecretInNamespace {
-  def apply(name: String): ConfigValue[String]
+sealed abstract class SecretInNamespace[F[_]] {
+  def apply(name: String): ConfigValue[F, String]
 
-  def apply(name: String, key: String): ConfigValue[String]
+  def apply(name: String, key: String): ConfigValue[F, String]
 }
 
 private[kubernetes] final object SecretInNamespace {
-  final def apply(namespace: String, client: ApiClient, blocker: Blocker): SecretInNamespace =
-    new SecretInNamespace {
-      override final def apply(name: String): ConfigValue[String] =
-        secret(client, name, namespace, None, blocker)
+  final def apply[F[_]](namespace: String, client: ApiClient): SecretInNamespace[F] =
+    new SecretInNamespace[F] {
+      override final def apply(name: String): ConfigValue[F, String] =
+        secret(client, name, namespace, None)
 
-      override final def apply(name: String, key: String): ConfigValue[String] =
-        secret(client, name, namespace, Some(key), blocker)
+      override final def apply(name: String, key: String): ConfigValue[F, String] =
+        secret(client, name, namespace, Some(key))
 
       override final def toString: String =
         s"SecretInNamespace($namespace)"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.5-SNAPSHOT"
+ThisBuild / version := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
In this new major version of Ciris, they moved to use Cats-Effect 3.x, which is binary incompatible with previous versions.
This means, that we also need to provide a new major version for Ciris-kubernetes.

Support for ciris-kubernetes 1.x can continue on the new branch [ciris-1.x](https://github.com/ovotech/ciris-kubernetes/tree/ciris-1.x)