### PR TITLE
Treat 404 errors from Kubernetes API as missing values

### DIFF
--- a/src/main/scala/ciris/kubernetes.scala
+++ b/src/main/scala/ciris/kubernetes.scala
@@ -107,7 +107,7 @@ package object kubernetes {
 
           ConfigValue.default(entries)
         } catch {
-          case cause: ApiException if cause.getMessage == "Not Found" =>
+          case cause: ApiException if cause.getMessage == "Not Found" || cause.getCode == 404 =>
             ConfigValue.missing(configKey)
         }
       }
@@ -131,7 +131,7 @@ package object kubernetes {
 
           ConfigValue.default(entries)
         } catch {
-          case cause: ApiException if cause.getMessage == "Not Found" =>
+          case cause: ApiException if cause.getMessage == "Not Found" || cause.getCode == 404 =>
             ConfigValue.missing(configKey)
         }
       }


### PR DESCRIPTION
Rather than relying on the message returned from the kubernetes api
being exactly "Not Found" we now also treat HTTP code 404 as a
missing configuration value. This is much more robust to changes
as it is unlikely that the HTTP status code spec will change while
kubernetes can decide to change the error message at any point in
time.