### PR TITLE
Bump kubernetes.io:client-java to 14.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val scalaSettings = Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.kubernetes" % "client-java" % "14.0.0",
+  "io.kubernetes" % "client-java" % "14.0.1",
   "io.kubernetes" % "client-java-api" % "14.0.0",
   "is.cir" %% "ciris" % "2.2.1"
 )


### PR DESCRIPTION
this fixes a CVE in protobuf:

```
  Upgrade io.kubernetes:client-java@14.0.0 to io.kubernetes:client-java@14.0.1 to fix
  ✗ Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-2331703] in com.google.protobuf:protobuf-java@3.19.1
    introduced by io.kubernetes:client-java@14.0.0 > com.google.protobuf:protobuf-java@3.19.1 and 1 other path(s)
```