### PR TITLE
Update dependency versions (2.x)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ lazy val metadataSettings = Seq(
 )
 
 lazy val scalaSettings = Seq(
-  scalaVersion := "2.13.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.15"),
+  scalaVersion := "2.13.10",
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.17"),
   scalacOptions ++= {
     val commonScalacOptions =
       Seq(
@@ -46,9 +46,9 @@ lazy val scalaSettings = Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.kubernetes" % "client-java" % "14.0.1",
-  "io.kubernetes" % "client-java-api" % "14.0.1",
-  "is.cir" %% "ciris" % "2.3.2"
+  "io.kubernetes" % "client-java" % "16.0.2",
+  "io.kubernetes" % "client-java-api" % "16.0.2",
+  "is.cir" %% "ciris" % "2.3.3"
 )
 
 licenses += ("MIT", url("https://opensource.org/licenses/MIT"))

--- a/src/main/scala/ciris/kubernetes.scala
+++ b/src/main/scala/ciris/kubernetes.scala
@@ -6,7 +6,7 @@ import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.util.Config
 
 import java.nio.charset.StandardCharsets
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 package object kubernetes {
   final def configMapInNamespace[F[_]](

--- a/src/main/scala/ciris/kubernetes.scala
+++ b/src/main/scala/ciris/kubernetes.scala
@@ -6,7 +6,7 @@ import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.util.Config
 
 import java.nio.charset.StandardCharsets
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._ // cannot be upgraded to scala.jdk.CollectionConverters because 2.12 does not support
 
 package object kubernetes {
   final def configMapInNamespace[F[_]](


### PR DESCRIPTION
* Scala library to fix CVE https://security.snyk.io/vuln/SNYK-JAVA-ORGSCALALANG-3032987
* Minor bump in Ciris
* Kubernetes Java library

```Issues to fix by upgrading:

  Upgrade io.kubernetes:client-java@14.0.1 to io.kubernetes:client-java@16.0.1 to fix
  ✗ Stack-based Buffer Overflow [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-3016888] in org.yaml:snakeyaml@1.29
    introduced by io.kubernetes:client-java@14.0.1 > org.yaml:snakeyaml@1.29
  ✗ Stack-based Buffer Overflow [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-3016889] in org.yaml:snakeyaml@1.29
    introduced by io.kubernetes:client-java@14.0.1 > org.yaml:snakeyaml@1.29
  ✗ Stack-based Buffer Overflow [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-3016891] in org.yaml:snakeyaml@1.29
    introduced by io.kubernetes:client-java@14.0.1 > org.yaml:snakeyaml@1.29
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-2806360] in org.yaml:snakeyaml@1.29
    introduced by io.kubernetes:client-java@14.0.1 > org.yaml:snakeyaml@1.29
  ✗ Information Exposure [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044] in com.squareup.okhttp3:okhttp@4.9.1
    introduced by io.kubernetes:client-java-api@14.0.1 > com.squareup.okhttp3:okhttp@4.9.1 and 3 other path(s)

  Upgrade io.kubernetes:client-java-api@14.0.1 to io.kubernetes:client-java-api@15.0.0 to fix
  ✗ Information Exposure [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044] in com.squareup.okhttp3:okhttp@4.9.1
    introduced by io.kubernetes:client-java-api@14.0.1 > com.squareup.okhttp3:okhttp@4.9.1 and 3 other path(s)

```