### PR TITLE
Port dependency patches for 1.x branch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ lazy val metadataSettings = Seq(
 )
 
 lazy val scalaSettings = Seq(
-  scalaVersion := "2.13.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.15"),
+  scalaVersion := "2.13.10",
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.17"),
   scalacOptions ++= {
     val commonScalacOptions =
       Seq(
@@ -47,8 +47,8 @@ lazy val scalaSettings = Seq(
 
 libraryDependencies ++= Seq(
   "is.cir" %% "ciris" % "1.2.1",
-  "io.kubernetes" % "client-java" % "14.0.1",
-  "io.kubernetes" % "client-java-api" % "14.0.1",
+  "io.kubernetes" % "client-java" % "16.0.2",
+  "io.kubernetes" % "client-java-api" % "16.0.2",
   "org.typelevel" %% "cats-core" % "2.6.1",
   "org.typelevel" %% "cats-effect" % "2.5.4",
   "org.scalameta" %% "munit" % "0.7.29" % Test,

--- a/src/main/scala/ciris/kubernetes.scala
+++ b/src/main/scala/ciris/kubernetes.scala
@@ -6,7 +6,7 @@ import io.kubernetes.client.openapi.{ApiClient, ApiException}
 import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.util.Config
 import java.nio.charset.StandardCharsets
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._ // cannot be upgraded to scala.jdk.CollectionConverters because 2.12 does not support
 
 package object kubernetes {
   final def configMapInNamespace(

--- a/src/main/scala/ciris/kubernetes.scala
+++ b/src/main/scala/ciris/kubernetes.scala
@@ -6,7 +6,7 @@ import io.kubernetes.client.openapi.{ApiClient, ApiException}
 import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.util.Config
 import java.nio.charset.StandardCharsets
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 package object kubernetes {
   final def configMapInNamespace(


### PR DESCRIPTION
This is the same as  #139 but for the Ciris 1.x version