### PR TITLE
Update Kubernetes API client to 18.0.0 (ciris-2.x)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,8 @@ lazy val scalaSettings = Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.kubernetes" % "client-java" % "17.0.0",
-  "io.kubernetes" % "client-java-api" % "17.0.0",
+  "io.kubernetes" % "client-java" % "18.0.0",
+  "io.kubernetes" % "client-java-api" % "18.0.0",
   "is.cir" %% "ciris" % "2.4.0"
 )
 


### PR DESCRIPTION
This is a bump which should fix library users getting this vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGBITBUCKETBC-5488281 
